### PR TITLE
Fix highilghting bugs

### DIFF
--- a/syntaxes/alicorn.tmLanguage.json
+++ b/syntaxes/alicorn.tmLanguage.json
@@ -41,21 +41,26 @@
 			"name": "comment.block.alicorn",
 			"begin": "^(\\t*)#",
 			"end": "^(?!\\1\\t)(?=\\t*\\S)",
-			"patterns": [
-				{
-				"name": "constant.character.escape.alicorn",
-				"match": "\\\\."
-				}
-			]
-		  }
+		  },
+		  {
+			"name": "comment.line.alicorn",
+			"begin": "#",
+			"end": "$",
+		  },
 		]
 		},
 		"strings": {
 			"patterns": [
 				{
 				"name": "string.block.alicorn",
-				"begin": "^(\\t*)\"\"\"\"",
+				"begin": "^(\\t*+)\"{4}",
 				"end": "^(?!\\1\\t)(?=\\t*\\S)"
+				"patterns": [
+					{
+					"name": "constant.character.escape.alicorn",
+					"match": "\\\\."
+					}
+				]
 				},
 				{
 				"name": "string.quoted.double.alicorn",
@@ -71,7 +76,7 @@
 				{
 				"name": "string.quoted.single.alicorn",
 				"begin": "'",
-				"end": "\"|$",
+				"end": "'|$",
 				"patterns": [
 					{
 					"name": "constant.character.escape.alicorn",


### PR DESCRIPTION
Highlighting was incorrect for:
single-quoted strings
single-line comments
backslash escapes in block strings
backslashes in comments